### PR TITLE
fix panic in SplitN and add tests

### DIFF
--- a/providerconfig/providerconfighttp/option.go
+++ b/providerconfig/providerconfighttp/option.go
@@ -16,17 +16,18 @@ package providerconfighttp
 
 import (
 	"fmt"
+	"log/slog"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/trace"
-	"log/slog"
-	"math"
-	"regexp"
-	"strconv"
-	"strings"
 )
 
 var (
@@ -142,7 +143,7 @@ func validateEndpoint(endpoint string) error {
 		return fmt.Errorf("invalid endpoint: %s", endpoint)
 	}
 	ne := protocolReg.ReplaceAllString(endpoint, "")
-	hostPort := strings.SplitN(ne, ":", 1)
+	hostPort := strings.SplitN(ne, ":", 2)
 	port, err := strconv.Atoi(hostPort[1])
 	if err != nil {
 		return err

--- a/providerconfig/providerconfighttp/option_test.go
+++ b/providerconfig/providerconfighttp/option_test.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Vincent Free
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providerconfighttp
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateEndpoint(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		input string
+		error error
+	}{
+		"without protocol": {
+			input: "randomurl",
+			error: fmt.Errorf("invalid endpoint: randomurl"),
+		},
+		"with http protocol": {
+			input: "http://localhost:1234",
+			error: nil,
+		},
+		"with https protocol": {
+			input: "https://localhost:12",
+			error: nil,
+		},
+		"port bigger than max value": {
+			input: "https://localhost:65536",
+			error: fmt.Errorf("invalid port value: 65536"),
+		},
+	}
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			// Act
+			err := validateEndpoint(testData.input)
+
+			// Assert
+			if testData.error == nil {
+				require.NoError(t, err)
+			} else {
+				require.Equal(t, testData.error, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix the `SplitN` to not panic when providing an endpoint with a port and add tests to check the `validateEndpoint` method